### PR TITLE
解决issue#27：在编辑表格的时候没有办法修改表格的共享状态

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -5,7 +5,7 @@
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
         <option name="externalProjectPath" value="$PROJECT_DIR$/backend_dataControl" />
-        <option name="gradleJvm" value="#JAVA_HOME" />
+        <option name="gradleJvm" value="11" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$/backend_dataControl" />

--- a/backend_dataControl/src/main/java/org/example/datacenter/controller/DataBaseController.java
+++ b/backend_dataControl/src/main/java/org/example/datacenter/controller/DataBaseController.java
@@ -68,4 +68,11 @@ public class DataBaseController {
             dataBaseService.updateTableData(tableName, dataToUpdate);
     }
 
+    @PostMapping("change_state")
+    public void changeTableState(@RequestBody Map<String, Object> requestData) {
+        String tableName = requestData.get("tableName").toString();
+        boolean permission = (boolean) requestData.get("permission");
+        dataBaseService.changeTableState(tableName, permission);
+    }
+
 }

--- a/backend_dataControl/src/main/java/org/example/datacenter/mapper/DataBaseMapper.java
+++ b/backend_dataControl/src/main/java/org/example/datacenter/mapper/DataBaseMapper.java
@@ -32,4 +32,6 @@ public interface DataBaseMapper {
     boolean getTablePermission(@Param("tableName") String tableName);
     List<TablePermissions> getAllTablePermission();
     Integer getTableId(@Param("tableName") String tableName); //从permissions表里面的到表格的id
+    void changeTableState(@Param("tableName") String tableName, @Param("permission") boolean permission);
 }
+

--- a/backend_dataControl/src/main/java/org/example/datacenter/service/DataBaseService.java
+++ b/backend_dataControl/src/main/java/org/example/datacenter/service/DataBaseService.java
@@ -238,4 +238,8 @@ public class DataBaseService {
         dataBaseMapper.insertData(tableName, dataToInsert);
     }
 
+    public void changeTableState(String tableName, boolean permission) {
+        dataBaseMapper.changeTableState(tableName, permission);
+    }
+
 }

--- a/backend_dataControl/src/main/resources/mapper/DataBaseMapper.xml
+++ b/backend_dataControl/src/main/resources/mapper/DataBaseMapper.xml
@@ -82,4 +82,10 @@
         </trim>
     </insert>
 
+    <update id="changeTableState">
+        UPDATE table_permissions
+        SET permission = #{permission}
+        WHERE name = #{tableName}
+    </update>
+
 </mapper>


### PR DESCRIPTION
解决方案为：增加一个changeTableState的接口，接收前端的表格名称和共享状态两个参数，在 table permissions 表格中修改共享权限信息。